### PR TITLE
Add photo handler using filter_and_identify

### DIFF
--- a/photo_handler.py
+++ b/photo_handler.py
@@ -1,0 +1,23 @@
+from limits.rate_limit import (
+    check_photo_limit,
+    check_rate_limit,
+    register_photo_usage,
+)
+from photo_filter import filter_and_identify
+
+
+# BLOCK 1:
+async def handle_photo(user_id: int, image_path: str) -> str:
+    """Process uploaded photo and return recognition result message."""
+    if not check_photo_limit(user_id):
+        return "❌ Лимит распознаваний на сегодня исчерпан."
+    if not check_rate_limit(user_id):
+        return "⌛ Подождите немного перед следующим распознаванием."
+
+    result = await filter_and_identify(image_path, user_id)
+
+    if result is None:
+        return "❌ Не удалось распознать растение. Попробуйте другое фото."
+
+    register_photo_usage(user_id)
+    return f"✅ Фото принято: {result['latin_name']} ({result['confidence']:.0%})"


### PR DESCRIPTION
## Summary
- implement new `handle_photo` in `photo_handler.py` that checks limits
- call new `filter_and_identify` routine for recognition results

## Testing
- `pytest -q`
- `python -m py_compile photo_handler.py service.py main.py limits/rate_limit.py`

------
https://chatgpt.com/codex/tasks/task_e_68789c9e81b0832ab175ed2ba9e1e140