### PR TITLE
Improve photo validation feedback

### DIFF
--- a/photo_handler.py
+++ b/photo_handler.py
@@ -16,8 +16,17 @@ async def handle_photo(user_id: int, image_path: str) -> str:
 
     result = await filter_and_identify(image_path, user_id)
 
-    if result is None:
-        return "❌ Не удалось распознать растение. Попробуйте другое фото."
+    if not result or result.get("error"):
+        error = result.get("error") if result else None
+        if error == "unsupported_format":
+            return "Формат изображения не поддерживается."
+        if error == "file_too_large":
+            return "Файл слишком большой."
+        if error == "bad_proportions":
+            return "Плохие пропорции изображения."
+        if error in {"no_suggestions", "low_confidence"}:
+            return "Растение не распознано."
+        return "Не удалось обработать изображение."
 
     register_photo_usage(user_id)
     return f"✅ Фото принято: {result['latin_name']} ({result['confidence']:.0%})"


### PR DESCRIPTION
## Summary
- return detailed error codes from `filter_and_identify`
- show specific user messages in `handle_photo`

## Testing
- `python -m py_compile photo_filter.py photo_handler.py main.py service.py limits/rate_limit.py`

------
https://chatgpt.com/codex/tasks/task_e_6878af91a12c832ab8e95311f5745ccd