### PR TITLE
Fix user_id type for daily limit check

### DIFF
--- a/main.py
+++ b/main.py
@@ -91,7 +91,7 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
             return
 
         # BLOCK 2: daily usage limit
-        if not await check_daily_limit(str(user_id)):
+        if not await check_daily_limit(user_id):
             await update.message.reply_text("🚫 Лимит на сегодня исчерпан. Попробуйте завтра.")
             return
 


### PR DESCRIPTION
## Summary
- prevent asyncpg errors caused by passing user_id as string

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878bf210dec832ab44e886b543856d4