### PR TITLE
Handle dict category_type

### DIFF
--- a/main.py
+++ b/main.py
@@ -240,6 +240,10 @@ async def get_care_card_html(latin_name: str) -> str | None:
                 return error
             try:
                 data = json.loads(gpt_content_stripped)
+                if isinstance(data.get("category_type"), dict):
+                    data["category_type"] = ", ".join(
+                        str(v) for v in data["category_type"].values()
+                    )
             except json.JSONDecodeError as e:
                 logger.error(
                     f"[get_care_card_html] JSON decode error: {e}. Content: {gpt_content_stripped}"


### PR DESCRIPTION
## Summary
- convert `category_type` from dicts to comma-separated strings when parsing GPT response

## Testing
- `python -m py_compile main.py service.py limit_checker.py`

------
https://chatgpt.com/codex/tasks/task_e_68794042b688832abb8d3e1ba30188de